### PR TITLE
Fix the furnace threshold and run-time calculation

### DIFF
--- a/pi_temp.py
+++ b/pi_temp.py
@@ -133,7 +133,8 @@ def history():
     return render_template("history.html",  timezone = timezone,
                                             graphJSON = graphJSON,
                                             total_minutes = sum(streak_minutes),
-                                            range_hours = range_hours
+                                            range_hours = range_hours,
+                                            debug = streak_minutes,
                                             )
 # Calculate streak lengths (https://stackoverflow.com/a/20614650/2152245)                                            
 def streak_lengths(temps):
@@ -144,10 +145,10 @@ def streak_lengths(temps):
         for idx, (x, y) in enumerate(zip(temps, temps[1:])):
             if x > y:
                 streaks.append(idx - start)
-                start = idx
+                start = idx 
         else:
             streaks.append(idx - start + 1) 
-        long_streaks = [x for x in streaks if x > 3]
+        long_streaks = [x-1 for x in streaks if x > 4]
         return long_streaks
         
 def get_records():

--- a/templates/history.html
+++ b/templates/history.html
@@ -82,7 +82,7 @@
 
     <div class='row' id='plotly-plot'></div>
 
-    {{ debug }}
+
 
   </body>
       

--- a/templates/history.html
+++ b/templates/history.html
@@ -78,9 +78,11 @@
       </div>
     </div>
     
-    Furnace averaging {{ "%.0f" % (total_minutes/range_hours) }} minutes/hr ({{ total_minutes }} minutes total).
+    Furnace averaging {{ "%.0f" % (total_minutes/range_hours) }} minutes/hour ({{ total_minutes }} minutes total).
 
     <div class='row' id='plotly-plot'></div>
+
+    {{ debug }}
 
   </body>
       

--- a/templates/history.html
+++ b/templates/history.html
@@ -82,7 +82,7 @@
 
     <div class='row' id='plotly-plot'></div>
 
-
+    {{ debug }}
 
   </body>
       


### PR DESCRIPTION
- Subtract one timestep to get duration of run.
- Increase the threshold for a long streak of increasing values so short streaks of equal values don't count as a furnace run. 

Need to improve the streak function.